### PR TITLE
PRO-1794: backport of 3.x fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,8 @@ If the same module exists in two places, an exception is thrown.
 
 **The 2.x series is deprecated for new work, as its functionality was folded into Apostrophe 3.x. See below for 1.x release notes relevant to maintenance of Apostrophe 2.x.**
 
+1.3.1: `moog-require` loads modules from npm if they exist there and are configured by name in the application. This was always intended only as a way to load direct, intentional dependencies of your project. However, since npm "flattens" the dependency tree, dependencies of dependencies that happen to have the same name as a project-level module could be loaded by default, crashing the site or causing unexpected behavior. So beginning with this release, `moog-require` scans `package.json` to verify an npm module is actually a dependency of the project itself before attempting to load it.
+
 1.3.0: achieved an approximately 100x performance improvement when `nestedModuleSubdirs` is in use by fetching
 a list of index.js files on the first `define` call and then searching that prefetched list each
 time. This solution is much faster than the glob module cache.

--- a/index.js
+++ b/index.js
@@ -159,6 +159,17 @@ module.exports = function(options) {
     if (_.has(self.bundled, type)) {
       return self.bundled[type];
     }
+    // Even if the package exists in node_modules it might just be a
+    // sub-dependency due to npm/yarn flattening, which means we could be
+    // confused by an unrelated npm module with the same name as an Apostrophe
+    // module unless we verify it is a real project-level dependency
+    if (!self.validPackages) {
+      const info = JSON.parse(fs.readFileSync(`${path.dirname(self.root.filename)}/package.json`, 'utf8'));
+      self.validPackages = new Set([ ...Object.keys(info.dependencies || {}), Object.keys(info.devDependencies || {}) ]);
+    }
+    if (!self.validPackages.has(type)) {
+      return null;
+    }
     try {
       return npmResolve.sync(type, { basedir: path.dirname(parentPath) });
     } catch (e) {

--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ module.exports = function(options) {
     // module unless we verify it is a real project-level dependency
     if (!self.validPackages) {
       const info = JSON.parse(fs.readFileSync(`${path.dirname(self.root.filename)}/package.json`, 'utf8'));
-      self.validPackages = new Set([ ...Object.keys(info.dependencies || {}), Object.keys(info.devDependencies || {}) ]);
+      self.validPackages = new Set([ ...Object.keys(info.dependencies || {}), ...Object.keys(info.devDependencies || {}) ]);
     }
     if (!self.validPackages.has(type)) {
       return null;

--- a/package.json
+++ b/package.json
@@ -38,5 +38,5 @@
   "scripts": {
     "test": "mocha test/test.js"
   },
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/test/node_modules/sameNameAsTransitiveDependency/index.js
+++ b/test/node_modules/sameNameAsTransitiveDependency/index.js
@@ -1,0 +1,1 @@
+throw new Error('This should never have been loaded from npm because it is not in package.json');

--- a/test/package.json
+++ b/test/package.json
@@ -9,7 +9,9 @@
     "metadataNpm": "1.0.0",
     "replaceTestOriginal": "1.0.0",
     "replaceTestReplacement": "1.0.0",
-    "testBeforeConstructAsync": "1.0.0",
+    "testBeforeConstructAsync": "1.0.0"
+  },
+  "devDependencies": {
     "testBundle": "1.0.0",
     "testModule": "1.0.0",
     "testModuleFour": "1.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,20 @@
+{
+  "dependencies": {
+    "failingBeforeConstructAsync": "1.0.0",
+    "failingBeforeConstructSync": "1.0.0",
+    "failingModuleAsync": "1.0.0",
+    "failingModuleSync": "1.0.0",
+    "improveTestOriginal": "1.0.0",
+    "improveTestReplacement": "1.0.0",
+    "metadataNpm": "1.0.0",
+    "replaceTestOriginal": "1.0.0",
+    "replaceTestReplacement": "1.0.0",
+    "testBeforeConstructAsync": "1.0.0",
+    "testBundle": "1.0.0",
+    "testModule": "1.0.0",
+    "testModuleFour": "1.0.0",
+    "testModuleThree": "1.0.0",
+    "testModuleTwo": "1.0.0",
+    "testOrderOfOperations": "1.0.0"
+  }
+}

--- a/test/project_modules/sameNameAsTransitiveDependency/index.js
+++ b/test/project_modules/sameNameAsTransitiveDependency/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  construct(self) {
+    self.confirm = 'loaded';
+  }
+};

--- a/test/test.js
+++ b/test/test.js
@@ -200,24 +200,6 @@ describe('moog', function() {
       });
     });
 
-    it('should create a subclass when the parent is an npm dependency of the subclass', function(done) {
-      synth = require('../index.js')({
-        localModules: __dirname + '/project_modules',
-        root: module
-      });
-
-      synth.define({
-        'testModuleFour': {}
-      });
-
-      synth.create('testModuleFour', {}, function(err, testModuleFour) {
-        assert(!err);
-        assert(testModuleFour);
-        assert(testModuleFour._options.age === 70);
-        return done();
-      });
-    });
-
   });
 
 
@@ -806,5 +788,13 @@ describe('moog', function() {
       assert(instance._options.color === 'green');
     });
   });
-
+  it('should load a project level module properly when a transitive dependency not in package.json nevertheless has the same name and appears in node_modules', function() {
+    var synth = require('../index.js')({
+      localModules: __dirname + '/project_modules',
+      root: module
+    });
+    synth.define('sameNameAsTransitiveDependency');
+    var instance = synth.create('sameNameAsTransitiveDependency', {});
+    assert(instance.confirm === 'loaded');
+  });
 });


### PR DESCRIPTION
Also removed a misguided test for an undocumented and unsupported feature that is inherently incompatible with the necessary security implications of this fix.

We should get this in for this week's release for parity since there are (mild) security implications.